### PR TITLE
Improve sorting and rank positions in standings

### DIFF
--- a/tippspiel2-ember/src/main/webapp/app/controllers/standings.js
+++ b/tippspiel2-ember/src/main/webapp/app/controllers/standings.js
@@ -14,10 +14,7 @@ export default Controller.extend({
     return this.get('model.standings').toArray()
       .sort((s1, s2) => compare(s1, s2))
       .map((value, index, arr) => {
-        value.set('position', (index == 0 ? 1 :
-                               arr[index-1].get('position') +
-                               (compare(value, arr[index-1]) > 0 ? 1 : 0))
-                 );
+        value.set('position', (index == 0 ? 1 : (compare(value, arr[index-1]) > 0 ? index+1 : "")));
 
         const championBet = this.get('model.championBets').find(cB => cB.get('user.id') === value.get('user.id'));
 

--- a/tippspiel2-ember/src/main/webapp/app/controllers/standings.js
+++ b/tippspiel2-ember/src/main/webapp/app/controllers/standings.js
@@ -3,15 +3,21 @@ import {computed} from '@ember/object';
 
 export default Controller.extend({
   standingsAsTable: computed('model.standings', 'model.championBets', 'model.competition', function () {
+    function compare(s1, s2) {
+      return  (s2.get('points') - s1.get('points')
+               || s2.get('exactBets') - s1.get('exactBets')
+               || s2.get('goalDifferenceBets') - s1.get('goalDifferenceBets')
+               || s2.get('winnerBets') - s1.get('winnerBets')
+               || s1.get('missedBets') - s2.get('missedBets')
+               || s2.get('wrongBets') - s1.get('wrongBets'))
+    }
     return this.get('model.standings').toArray()
-      .sort((s1, s2) =>
-        s2.get('points') - s1.get('points')
-        || s2.get('goalDifferenceBets') - s1.get('goalDifferenceBets')
-        || s2.get('winnerBets') - s1.get('winnerBets')
-        || s1.get('missedBets') - s2.get('missedBets')
-        || s2.get('wrongBets') - s1.get('wrongBets'))
-      .map((value, index) => {
-        value.set('position', index + 1);
+      .sort((s1, s2) => compare(s1, s2))
+      .map((value, index, arr) => {
+        value.set('position', (index == 0 ? 1 :
+                               arr[index-1].get('position') +
+                               (compare(value, arr[index-1]) > 0 ? 1 : 0))
+                 );
 
         const championBet = this.get('model.championBets').find(cB => cB.get('user.id') === value.get('user.id'));
 


### PR DESCRIPTION
* after points, exacts bets should have highest priority
* use the same criteria for rank positions as for sorting

TODO: integrate champion bet?